### PR TITLE
fixed: 获取不存在的值时会报错，报tab[idx] 是 null

### DIFF
--- a/data-structures/src/main/java/hash_table/HashMap04ByCoalescedHashing.java
+++ b/data-structures/src/main/java/hash_table/HashMap04ByCoalescedHashing.java
@@ -45,9 +45,11 @@ public class HashMap04ByCoalescedHashing<K, V> implements Map<K, V> {
     @Override
     public V get(K key) {
         int idx = key.hashCode() & (tab.length - 1);
-        while (tab[idx].key != key) {
+        while (tab[idx] != null && tab[idx].key != key) {
             idx = tab[idx].idxOfNext;
         }
+        if (tab[idx] == null)
+            return null;
         return tab[idx].value;
     }
 


### PR DESCRIPTION
如题